### PR TITLE
update subgraph endpoint to self-hosted

### DIFF
--- a/.github/workflows/onboarding-app-deploy-to-dev.yml
+++ b/.github/workflows/onboarding-app-deploy-to-dev.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/onboarding-app-deploy-to-dev.yml'
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/onboarding-app-deploy-to-dev.yml
+++ b/.github/workflows/onboarding-app-deploy-to-dev.yml
@@ -65,7 +65,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-dev.yml
+++ b/.github/workflows/onboarding-app-deploy-to-dev.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/onboarding-app-deploy-to-dev.yml'
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy:
@@ -65,7 +65,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-prod.yml
+++ b/.github/workflows/onboarding-app-deploy-to-prod.yml
@@ -5,7 +5,7 @@ on:
       - onboarding-app/release-*
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/onboarding-app-deploy-to-prod.yml
+++ b/.github/workflows/onboarding-app-deploy-to-prod.yml
@@ -5,7 +5,7 @@ on:
       - onboarding-app/release-*
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy:
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-prod.yml
+++ b/.github/workflows/onboarding-app-deploy-to-prod.yml
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-staging.yml
+++ b/.github/workflows/onboarding-app-deploy-to-staging.yml
@@ -5,7 +5,7 @@ on:
       - rc/onboarding-app/release-*
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy:
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-staging.yml
+++ b/.github/workflows/onboarding-app-deploy-to-staging.yml
@@ -5,7 +5,7 @@ on:
       - rc/onboarding-app/release-*
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/onboarding-app-deploy-to-staging.yml
+++ b/.github/workflows/onboarding-app-deploy-to-staging.yml
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-pull-request.yml
+++ b/.github/workflows/onboarding-app-pull-request.yml
@@ -63,7 +63,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-pull-request.yml
+++ b/.github/workflows/onboarding-app-pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/onboarding-app-pull-request.yml'
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy:
@@ -63,7 +63,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-pull-request.yml
+++ b/.github/workflows/onboarding-app-pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/onboarding-app-pull-request.yml'
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/tinlake-ui-deploy-to-dev.yml'
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy-to-goerli:

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -146,7 +146,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/tinlake-ui-deploy-to-dev.yml'
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy-to-goerli:
@@ -146,7 +146,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -67,7 +67,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -5,7 +5,7 @@ on:
       - tinlake-ui/release-*
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -5,7 +5,7 @@ on:
       - tinlake-ui/release-*
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy:
@@ -67,7 +67,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -5,7 +5,7 @@ on:
       - rc/tinlake-ui/release-*
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy-to-goerli:
@@ -143,7 +143,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -143,7 +143,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -5,7 +5,7 @@ on:
       - rc/tinlake-ui/release-*
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy-to-goerli:

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -144,7 +144,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/tinlake-ui-pull-request.yml'
 
 permissions:
-  contents: write
+   contents: write
 
 jobs:
   build-and-deploy-to-goerli:

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/tinlake-ui-pull-request.yml'
 
 permissions:
-   contents: write
+  contents: write
 
 jobs:
   build-and-deploy-to-goerli:
@@ -144,7 +144,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://api.thegraph.com/subgraphs/name/astox/main'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'http://graph.cntrfg.com/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/tinlake-ui/.env.mainnet-example
+++ b/tinlake-ui/.env.mainnet-example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE=QmUzKYLnX6WnNS44WrpbrUnqv2uQ3b4c1t8BYGYnJcN
 NEXT_PUBLIC_PORTIS_KEY=bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f
 NEXT_PUBLIC_REWARDS_TREE_URL=https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json
 NEXT_PUBLIC_RPC_URL=https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516
-NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=http://graph.cntrfg.com/subgraphs/name/main
+NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://graph.cntrfg.com/subgraphs/name/main
 NEXT_PUBLIC_TRANSACTION_TIMEOUT=3600

--- a/tinlake-ui/.env.mainnet-example
+++ b/tinlake-ui/.env.mainnet-example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE=QmUzKYLnX6WnNS44WrpbrUnqv2uQ3b4c1t8BYGYnJcN
 NEXT_PUBLIC_PORTIS_KEY=bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f
 NEXT_PUBLIC_REWARDS_TREE_URL=https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json
 NEXT_PUBLIC_RPC_URL=https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516
-NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://api.thegraph.com/subgraphs/name/astox/main
+NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=http://graph.cntrfg.com/subgraphs/name/main
 NEXT_PUBLIC_TRANSACTION_TIMEOUT=3600


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request updates the subgraph endpoint in tinlake to the new self-hosted subgraph, which has a bug fix for a recent issue where calling debt() on the NS2 pile was reverting.


