### PR TITLE
Update subgraph URL

### DIFF
--- a/.github/workflows/onboarding-app-deploy-to-dev.yml
+++ b/.github/workflows/onboarding-app-deploy-to-dev.yml
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-prod.yml
+++ b/.github/workflows/onboarding-app-deploy-to-prod.yml
@@ -59,7 +59,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-deploy-to-staging.yml
+++ b/.github/workflows/onboarding-app-deploy-to-staging.yml
@@ -59,7 +59,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/onboarding-app-pull-request.yml
+++ b/.github/workflows/onboarding-app-pull-request.yml
@@ -60,7 +60,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -143,7 +143,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -64,7 +64,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -140,7 +140,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -141,7 +141,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/tinlake'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://graph.centrifuge.io/subgraphs/name/main'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/tinlake-ui/.env.mainnet-example
+++ b/tinlake-ui/.env.mainnet-example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE=QmVbPHVLURB4XxCfhu1j5WAtwwHLcefz5gYgRraTLWp
 NEXT_PUBLIC_PORTIS_KEY=bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f
 NEXT_PUBLIC_REWARDS_TREE_URL=https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json
 NEXT_PUBLIC_RPC_URL=https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516
-NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://graph.centrifuge.io/tinlake
+NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://graph.centrifuge.io/subgraphs/name/main
 NEXT_PUBLIC_TRANSACTION_TIMEOUT=3600


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request swaps out the new fancy subgraph endpoint for the old style that points to the latest subgraph. I've lost permissions to update the /tinlake redirect we've adopted for subgraph endpoints, so until thats fixed I'll update it the old-fashioned way

