### PR TITLE
Fix tinlake asset lists

### DIFF
--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -294,36 +294,46 @@ class Apollo {
     const result = await this.client.query({
       query: gql`
         {
-          loans (first: 1000, where: { pool_in: ["${root.toLowerCase()}"]}) {
-            id
-            pool {
+          pools(where: { id_in: ["${root.toLowerCase()}"]}) {
+            loans (first: 1000) {
               id
+              pool {
+                id
+              }
+              index
+              owner
+              opened
+              closed
+              debt
+              interestRatePerSecond
+              ceiling
+              threshold
+              borrowsCount
+              borrowsAggregatedAmount
+              repaysCount
+              repaysAggregatedAmount
+              nftId
+              nftRegistry
+              maturityDate
+              financingDate
+              riskGroup
             }
-            index
-            owner
-            opened
-            closed
-            debt
-            interestRatePerSecond
-            ceiling
-            threshold
-            borrowsCount
-            borrowsAggregatedAmount
-            repaysCount
-            repaysAggregatedAmount
-            nftId
-            nftRegistry
-            maturityDate
-            financingDate
-            riskGroup
           }
         }
         `,
     })
+    if (!result.data?.pools) return { data: [] }
+    if (!result.data.pools[0]) return { data: [] }
+    if (!result.data.pools[0].loans) return { data: [] }
 
-    if (!result.data?.loans) return { data: [] }
+    const loans = result.data.pools.reduce((assets: any[], pool: any) => {
+      if (pool.loans) {
+        assets.push(...pool.loans)
+      }
+      return assets
+    }, [])
 
-    const tinlakeLoans = toTinlakeLoans(result.data.loans)
+    const tinlakeLoans = toTinlakeLoans(loans)
     return tinlakeLoans
   }
 

--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -322,9 +322,6 @@ class Apollo {
         }
         `,
     })
-    if (!result.data?.pools) return { data: [] }
-    if (!result.data.pools[0]) return { data: [] }
-    if (!result.data.pools[0].loans) return { data: [] }
 
     const loans = result.data.pools.reduce((assets: any[], pool: any) => {
       if (pool.loans) {
@@ -332,6 +329,8 @@ class Apollo {
       }
       return assets
     }, [])
+
+    if (!loans) return { data: [] }
 
     const tinlakeLoans = toTinlakeLoans(loans)
     return tinlakeLoans


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request changes the subgraph query for asset lists to query loans via pools first, instead of querying loans and filtering by pools. Affected pools are NS2 and Branch 3
