### PR TITLE
fix writeoffGroup fetching and conversion

### DIFF
--- a/tinlake-ui/containers/PoolManagement/Risk.tsx
+++ b/tinlake-ui/containers/PoolManagement/Risk.tsx
@@ -97,13 +97,13 @@ const Risk: React.FC<Props> = (props: Props) => {
   const addWriteOffGroup = () => {
     const newWriteOffGroup = {
       rate: new BN('1000000002378234398782343987'),
-      writeOffPercentage: new BN(0),
+      percentage: new BN(0),
       overdueDays: new BN(0),
     }
     setWriteOffGroups([...writeOffGroups, newWriteOffGroup])
   }
 
-  const updateWriteOffGroup = (group: number, key: 'writeOffPercentage' | 'rate' | 'overdueDays', value: string) => {
+  const updateWriteOffGroup = (group: number, key: 'percentage' | 'rate' | 'overdueDays', value: string) => {
     const newWriteOffGroups = writeOffGroups
     newWriteOffGroups[group][key] =
       key === 'rate'
@@ -115,7 +115,7 @@ const Risk: React.FC<Props> = (props: Props) => {
   }
 
   const saveWriteOffGroups = async () => {
-    console.log(writeOffGroups[0].writeOffPercentage.toString())
+    console.log(writeOffGroups[0].percentage.toString())
     const txId = await props.createTransaction(
       `Save ${writeOffGroups.length} write-off group${writeOffGroups.length > 1 ? 's' : ''}`,
       'addWriteOffGroups',
@@ -301,11 +301,11 @@ const Risk: React.FC<Props> = (props: Props) => {
                       <TableCell>
                         <FormField margin={{ right: 'small' }}>
                           <NumberInput
-                            value={baseToDisplay(Fixed27Base.sub(writeOffGroup.writeOffPercentage || new BN(0)), 25)}
+                            value={baseToDisplay(Fixed27Base.sub(writeOffGroup.percentage || new BN(0)), 25)}
                             suffix="%"
                             max={100}
                             precision={0}
-                            onValueChange={({ value }) => updateWriteOffGroup(id, 'writeOffPercentage', value)}
+                            onValueChange={({ value }) => updateWriteOffGroup(id, 'percentage', value)}
                             plain
                           />
                         </FormField>

--- a/tinlake-ui/utils/useWriteOffPercentage.ts
+++ b/tinlake-ui/utils/useWriteOffPercentage.ts
@@ -18,7 +18,8 @@ export async function calculateWriteOffPercentage(tinlake: ITinlake, loanId: num
     }
 
     return writeOffPercentage.div(new BN(10).pow(new BN(25))).toString()
-  } catch {
+  } catch (e) {
+    console.log(`Oops: ${e}`)
     return '0'
   }
 }

--- a/tinlake.js/src/actions/admin.ts
+++ b/tinlake.js/src/actions/admin.ts
@@ -202,7 +202,7 @@ export function AdminActions<ActionsBase extends Constructor<TinlakeParams>>(Bas
       return this.pending(
         this.contract('POOL_ADMIN').addWriteOffGroups(
           writeOffGroups.map((g) => g.rate.toString()),
-          writeOffGroups.map((g) => g.writeOffPercentage.toString()),
+          writeOffGroups.map((g) => g.percentage.toString()),
           writeOffGroups.map((g) => g.overdueDays.toString()),
           this.overrides
         )
@@ -237,13 +237,11 @@ export function AdminActions<ActionsBase extends Constructor<TinlakeParams>>(Bas
         return new BN(10).pow(new BN(27)).sub(new BN(percentage.toString()))
       } else if (navFeed.writeOffGroups) {
         const writeOffGroups = await this.getWriteOffGroups()
+        let { percentage } = writeOffGroups[rateGroup.sub(new BN(1000)).toNumber()]
+        if (percentage) {
+          percentage = new BN(10).pow(new BN(27)).sub(new BN(percentage.toString()))
 
-        const writeOffGroup = writeOffGroups.find((group) => rateGroup.eq(group.rate))
-
-        if (writeOffGroup) {
-          const writeOffPercentage = new BN(10).pow(new BN(27)).sub(writeOffGroup.writeOffPercentage) || new BN(0)
-
-          return writeOffPercentage
+          return percentage
         }
 
         return new BN(0)
@@ -302,7 +300,7 @@ export type IRiskGroup = {
 
 export type IWriteOffGroup = {
   rate: BN
-  writeOffPercentage: BN
+  percentage: BN
   overdueDays: BN
 }
 


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request fixes writeoffs displaying as overdue for v0.3.5 pools. Currently [this loan](https://legacy.tinlake.centrifuge.io/pool/0xd8486C565098360A24f858088a6D29a380dDF7ec/flowcarbon-1/assets/asset?assetId=3) is incorrectly showing as overdue.