### PR TITLE
chore: change verbiage of banner

### DIFF
--- a/tinlake-ui/components/ExpiredCFGRewardsBanner.tsx
+++ b/tinlake-ui/components/ExpiredCFGRewardsBanner.tsx
@@ -1,0 +1,44 @@
+import { Anchor, Box, Card, Paragraph } from 'grommet'
+
+export const ExpiredCFGRewardsBanner = () => {
+  const expirationDate = new Date('2024-01-29T15:01')
+  const currentDateCET = new Date().toLocaleString('en-US', { timeZone: 'Europe/Berlin' })
+  const currentDateCETMillis = new Date(currentDateCET).getTime()
+
+  const isExpired = currentDateCETMillis > expirationDate.getTime()
+
+  if (isExpired) {
+    const formattedExpirationDate = `${expirationDate.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })} at ${expirationDate
+      .toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })
+      .toLowerCase()}`
+
+    return (
+      <Card
+        margin={{ top: 'medium', bottom: 'xsmall' }}
+        pad={{ top: 'xsmall', bottom: 'xsmall', left: 'medium', right: 'medium' }}
+        style={{
+          backgroundColor: '#fff5da',
+        }}
+      >
+        <Box>
+          <Paragraph>
+            The Tinlake Reward program has been discontinued by community vote. All unclaimed CFG rewards expired on{' '}
+            {formattedExpirationDate} CET and can no longer be collected. Read more about the community vote{' '}
+            <Anchor
+              href="https://gov.centrifuge.io/t/cp81-unclaimed-tinlake-rewards/5885/4"
+              label="here"
+              target="_blank"
+            />
+            .
+          </Paragraph>
+        </Box>
+      </Card>
+    )
+  }
+
+  return null
+}

--- a/tinlake-ui/components/ExpiringCFGRewardsBanner.tsx
+++ b/tinlake-ui/components/ExpiringCFGRewardsBanner.tsx
@@ -2,10 +2,12 @@ import { Anchor, Box, Card, Paragraph } from 'grommet'
 
 export const ExpiringCFGRewardsBanner = () => {
   const expirationDate = new Date('2024-01-29T15:01')
-  const currentDateCET = new Date().toLocaleString('en-US', { timeZone: 'CET' })
+  const currentDateCET = new Date().toLocaleString('en-US', { timeZone: 'Europe/Berlin' })
   const currentDateCETMillis = new Date(currentDateCET).getTime()
 
   const isExpired = currentDateCETMillis > expirationDate.getTime()
+
+  if (isExpired) return null
 
   const formattedExpirationDate = `${expirationDate.toLocaleString('en-US', {
     month: 'short',
@@ -15,7 +17,7 @@ export const ExpiringCFGRewardsBanner = () => {
 
   return (
     <Card
-      margin={{ top: 'medium' }}
+      margin={{ top: 'medium', bottom: 'xsmall' }}
       pad={{ top: 'xsmall', bottom: 'xsmall', left: 'medium', right: 'medium' }}
       style={{
         backgroundColor: '#fff5da',
@@ -23,15 +25,16 @@ export const ExpiringCFGRewardsBanner = () => {
     >
       <Box>
         <Paragraph>
-          {isExpired ? (
-            `CFG rewards expired on ${formattedExpirationDate} CET.`
-          ) : (
-            <>
-              Claim your rewards until {formattedExpirationDate} CET. After this day, users will not be able to claim
-              their CFG rewards. Check <Anchor href="/rewards" label="here" /> if there are still unclaimed rewards.
-            </>
-          )}{' '}
-          Read more <Anchor href="https://gov.centrifuge.io/t/cp81-unclaimed-tinlake-rewards/5885/4" label="here" />.
+          Claim your Tinlake Rewards before it is too late. Rewards will expire on {formattedExpirationDate} CET. After
+          the deadline, users will not be able to claim their CFG rewards. Check{' '}
+          <Anchor href="/rewards" label="here" target="_blank" /> if you have unclaimed rewards. Read more about the
+          community vote{' '}
+          <Anchor
+            href="https://gov.centrifuge.io/t/cp81-unclaimed-tinlake-rewards/5885/4"
+            label="here"
+            target="_blank"
+          />
+          .
         </Paragraph>
       </Box>
     </Card>

--- a/tinlake-ui/components/ExploreCentrifugeBanner.tsx
+++ b/tinlake-ui/components/ExploreCentrifugeBanner.tsx
@@ -2,7 +2,7 @@ import { Anchor, Box, Card, Paragraph } from 'grommet'
 
 export const ExploreCentrifugeBanner = () => (
   <Card
-    margin={{ top: 'medium' }}
+    margin={{ top: 'medium', bottom: 'xsmall' }}
     pad={{ top: 'xsmall', bottom: 'xsmall', left: 'medium', right: 'medium' }}
     style={{
       backgroundColor: '#cde5ff',

--- a/tinlake-ui/pages/rewards.tsx
+++ b/tinlake-ui/pages/rewards.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head'
 import * as React from 'react'
 import Auth from '../components/Auth'
 import Container from '../components/Container'
+import { ExpiredCFGRewardsBanner } from '../components/ExpiredCFGRewardsBanner'
 import Header from '../components/Header'
 import { IpfsPoolsProvider } from '../components/IpfsPoolsProvider'
 import { TinlakeProvider } from '../components/TinlakeProvider'
@@ -28,6 +29,11 @@ const RewardsPage: React.FC<Props> = (props: Props) => {
             <title>CFG Rewards | Tinlake | Centrifuge</title>
           </Head>
           <Header selectedRoute={''} menuItems={[]} ipfsPools={props.ipfsPools} hideRewardsBanner />
+          <Box justify="center" direction="row">
+            <Box width="xlarge">
+              <ExpiredCFGRewardsBanner />
+            </Box>
+          </Box>
           <Container style={{ backgroundColor: '#f9f9f9' }}>
             <Box justify="center" direction="row">
               <Box width="xlarge">


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request updates the verbiage of the expiring cfg rewards banner. Also, once rewards expire, the banner will only display on the `/rewards` page.

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

[#1869](https://github.com/centrifuge/apps/issues/1869)

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [x] Dev

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

<img width="1247" alt="image" src="https://github.com/centrifuge/tinlake-apps/assets/28536523/6a18cd98-5428-45dd-a4f5-84099fa31a37">